### PR TITLE
Add default values when browsing for a room.

### DIFF
--- a/internal/api/models.go
+++ b/internal/api/models.go
@@ -26,7 +26,7 @@ type CosoftBookingPayload struct {
 
 type BrowsePayload struct {
 	Room      uint
-	StarDate  string
+	StartDate string
 	StartHour string
 	EndDate   string
 	Duration  int

--- a/internal/ui/main.go
+++ b/internal/ui/main.go
@@ -9,6 +9,8 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
+const timeOnlyFormat = "15:04"
+
 type UI struct{}
 
 func NewUI() *UI {
@@ -50,12 +52,14 @@ func validateDateIsFuture(s string) error {
 	}
 
 	date, err := time.Parse(time.DateOnly, s)
-
 	if err != nil {
 		return fmt.Errorf("date could not be parsed")
 	}
 
-	if time.Now().After(date) {
+	// Compute the today's date and compare it with the input.
+	now := time.Now()
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	if date.Before(today) {
 		return fmt.Errorf("date is not in the future")
 	}
 
@@ -67,7 +71,7 @@ func validateHour(s string) error {
 		return fmt.Errorf("hour is required")
 	}
 
-	h, err := time.Parse("15:04", s)
+	h, err := time.Parse(timeOnlyFormat, s)
 
 	if err != nil {
 		return fmt.Errorf("could not parse time")
@@ -86,4 +90,9 @@ func validateHour(s string) error {
 	}
 
 	return nil
+}
+
+// roundHourToQuarter rounds t to the next quarter hour.
+func roundHourToQuarter(t time.Time) time.Time {
+	return t.Truncate(15 * time.Minute).Add(15 * time.Minute)
 }

--- a/internal/ui/main_test.go
+++ b/internal/ui/main_test.go
@@ -1,0 +1,48 @@
+package ui
+
+import (
+	"testing"
+	"time"
+)
+
+func Test_roundHourToQuarter(t *testing.T) {
+	tests := []struct {
+		name string // description of this test case
+		t    time.Time
+		want time.Time
+	}{
+		{
+			name: "first_quarter",
+			t:    time.Date(2026, 1, 27, 13, 8, 0, 0, time.Local),
+			want: time.Date(2026, 1, 27, 13, 15, 0, 0, time.Local),
+		},
+		{
+			name: "second_quarter",
+			t:    time.Date(2026, 1, 27, 13, 23, 0, 0, time.Local),
+			want: time.Date(2026, 1, 27, 13, 30, 0, 0, time.Local),
+		},
+		{
+			name: "third_quarter",
+			t:    time.Date(2026, 1, 27, 13, 38, 0, 0, time.Local),
+			want: time.Date(2026, 1, 27, 13, 45, 0, 0, time.Local),
+		},
+		{
+			name: "next_hour",
+			t:    time.Date(2026, 1, 27, 13, 53, 0, 0, time.Local),
+			want: time.Date(2026, 1, 27, 14, 0, 0, 0, time.Local),
+		},
+		{
+			name: "next_quarter",
+			t:    time.Date(2026, 1, 27, 14, 0, 0, 0, time.Local),
+			want: time.Date(2026, 1, 27, 14, 15, 0, 0, time.Local),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := roundHourToQuarter(tt.t)
+			if got != tt.want {
+				t.Errorf("roundHourToQuarter() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit adds default values for date and hours when browsing for a room. It also fixes a typo in `internal/api.BrowsePayload`.